### PR TITLE
ODP-2017 Livy CVE's reconciliation from ODP-3.2.3.2-3 to ODP-main.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-api</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-assembly</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-common/pom.xml
+++ b/client-common/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-common</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/client-http/pom.xml
+++ b/client-http/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-client-http</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,12 +22,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-core-parent</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.11/pom.xml
+++ b/core/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.11</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/core/scala-2.12/pom.xml
+++ b/core/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-core_2.12</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-core-parent</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <artifactId>livy-coverage-report</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-examples</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <artifactId>livy-integration-test</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -92,14 +92,14 @@
 
   <properties>
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
-    <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
+    <hadoop.version>3.2.3.3.2.3.2-3</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <slf4j.version>1.7.35</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
-    <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.8.3.2.3.2-2</spark.scala-2.12.version>
+    <spark.scala-2.11.version>2.4.8.3.2.3.2-3</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.8.3.2.3.2-3</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
-    <hive.version>3.1.4.3.2.3.2-2</hive.version>
+    <hive.version>3.1.4.3.2.3.2-3</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
@@ -148,7 +148,7 @@
     <ldap-api.version>1.0.0-M33</ldap-api.version>
 
     <curator.version>2.7.1</curator.version>
-    <zookeeper.version>3.5.10.3.2.3.2-2</zookeeper.version>
+    <zookeeper.version>3.5.10.3.2.3.2-3</zookeeper.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
@@ -1198,7 +1198,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.8.3.2.3.2-3</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.77.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.77.Final</netty.spark-2.11.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -92,14 +92,14 @@
 
   <properties>
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
-    <hadoop.version>3.2.3.3.2.3.2-3</hadoop.version>
+    <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <slf4j.version>1.7.35</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
-    <spark.scala-2.11.version>2.4.8.3.2.3.2-3</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.8.3.2.3.2-3</spark.scala-2.12.version>
+    <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.8.3.2.3.2-2</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
-    <hive.version>3.1.4.3.2.3.2-3</hive.version>
+    <hive.version>3.1.4.3.2.3.2-2</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
@@ -148,7 +148,7 @@
     <ldap-api.version>1.0.0-M33</ldap-api.version>
 
     <curator.version>2.7.1</curator.version>
-    <zookeeper.version>3.5.10.3.2.3.2-3</zookeeper.version>
+    <zookeeper.version>3.5.10.3.2.3.2-2</zookeeper.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
@@ -212,17 +212,6 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
-    <repository>
-            <id>acceldata repo</id>
-            <name>acceldata repo</name>
-            <url>https://repo1.acceldata.dev/repository/odp-central/</url>
-            <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-        </repository>
   </repositories>
 
   <modules>
@@ -1209,7 +1198,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.8.3.2.3.2-3</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.77.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.77.Final</netty.spark-2.11.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -92,14 +92,14 @@
 
   <properties>
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
-    <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
+    <hadoop.version>3.2.3.3.2.3.2-3</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <slf4j.version>1.7.35</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
-    <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.8.3.2.3.2-2</spark.scala-2.12.version>
+    <spark.scala-2.11.version>2.4.8.3.2.3.2-3</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.8.3.2.3.2-3</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
-    <hive.version>3.1.4.3.2.3.2-2</hive.version>
+    <hive.version>3.1.4.3.2.3.2-3</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
@@ -148,7 +148,7 @@
     <ldap-api.version>1.0.0-M33</ldap-api.version>
 
     <curator.version>2.7.1</curator.version>
-    <zookeeper.version>3.5.10.3.2.3.2-2</zookeeper.version>
+    <zookeeper.version>3.5.10.3.2.3.2-3</zookeeper.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
@@ -1209,7 +1209,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.8.3.2.3.2-3</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.77.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.77.Final</netty.spark-2.11.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -92,14 +92,14 @@
 
   <properties>
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
-    <hadoop.version>3.2.3.3.2.2.0-1095</hadoop.version>
+    <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <slf4j.version>1.7.35</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
-    <spark.scala-2.11.version>2.4.8.3.2.2.0-1095</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.8.3.2.2.0-1095</spark.scala-2.12.version>
+    <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.8.3.2.3.2-2</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
-    <hive.version>3.1.4.3.2.2.0-1095</hive.version>
+    <hive.version>3.1.4.3.2.3.2-2</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
@@ -148,7 +148,7 @@
     <ldap-api.version>1.0.0-M33</ldap-api.version>
 
     <curator.version>2.7.1</curator.version>
-    <zookeeper.version>3.5.10.3.2.2.0-1095</zookeeper.version>
+    <zookeeper.version>3.5.10.3.2.3.2-2</zookeeper.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
@@ -1209,7 +1209,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.8.3.2.2.0-1095</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.8.3.2.3.2-2</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.77.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.77.Final</netty.spark-2.11.version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,14 +92,14 @@
 
   <properties>
     <asynchttpclient.version>2.10.1</asynchttpclient.version>
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>3.2.3.3.2.2.0-1095</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <slf4j.version>1.7.35</slf4j.version>
     <reload4j.version>1.2.25</reload4j.version>
-    <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
-    <spark.scala-2.12.version>2.4.5</spark.scala-2.12.version>
+    <spark.scala-2.11.version>2.4.8.3.2.2.0-1095</spark.scala-2.11.version>
+    <spark.scala-2.12.version>2.4.8.3.2.2.0-1095</spark.scala-2.12.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
-    <hive.version>3.0.0</hive.version>
+    <hive.version>3.1.4.3.2.2.0-1095</hive.version>
     <commons-codec.version>1.9</commons-codec.version>
     <httpclient.version>4.5.3</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
@@ -131,9 +131,9 @@
     <execution.root>${user.dir}</execution.root>
     <spark.home>${execution.root}/dev/spark</spark.home>
     <spark.bin.download.url>
-      https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
+      https://archive.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
     </spark.bin.download.url>
-    <spark.bin.name>spark-2.4.5-bin-hadoop2.7</spark.bin.name>
+    <spark.bin.name>spark-2.4.8-bin-hadoop2.7</spark.bin.name>
     <!--  used for testing, NCSARequestLog use it for access log  -->
     <livy.log.dir>${basedir}/target</livy.log.dir>
 
@@ -148,7 +148,7 @@
     <ldap-api.version>1.0.0-M33</ldap-api.version>
 
     <curator.version>2.7.1</curator.version>
-    <zookeeper.version>3.4.6</zookeeper.version>
+    <zookeeper.version>3.5.10.3.2.2.0-1095</zookeeper.version>
 
     <!--
       Properties for the copyright header style checks. Modules that use the ASF header
@@ -247,6 +247,7 @@
     <module>server</module>
     <module>test-lib</module>
     <module>integration-test</module>
+    <module>thriftserver/server</module>
   </modules>
 
   <dependencies>
@@ -1208,7 +1209,7 @@
       </activation>
       <properties>
         <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-        <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
+        <spark.scala-2.11.version>2.4.8.3.2.2.0-1095</spark.scala-2.11.version>
         <spark.version>${spark.scala-2.11.version}</spark.version>
         <netty.spark-2.12.version>4.1.77.Final</netty.spark-2.12.version>
         <netty.spark-2.11.version>4.1.77.Final</netty.spark-2.11.version>
@@ -1219,9 +1220,9 @@
         <json4s.spark-2.12.version>3.6.6</json4s.spark-2.12.version>
         <json4s.version>${json4s.spark-2.11.version}</json4s.version>
         <spark.bin.download.url>
-          https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz
+          https://archive.apache.org/dist/spark/spark-3.2.2/spark-3.2.2-bin-hadoop3.2.tgz
         </spark.bin.download.url>
-        <spark.bin.name>spark-3.1.2-bin-hadoop3.2</spark.bin.name>
+        <spark.bin.name>spark-3.2.2-bin-hadoop3.2</spark.bin.name>
       </properties>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-main</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
   <name>Livy Project Parent POM</name>
   <description>Livy Project</description>
@@ -1170,7 +1170,7 @@
             <configuration>
               <resourceBundles>
                 <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
-                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
+                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.5</resourceBundle>
               </resourceBundles>
             </configuration>
           </execution>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <build>

--- a/python-api/pom.xml
+++ b/python-api/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-python-api</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <build>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/pom.xml
+++ b/repl/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
     <relativePath>../scala/pom.xml</relativePath>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <artifactId>livy-repl-parent</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.11/pom.xml
+++ b/repl/scala-2.11/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.11</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/repl/scala-2.12/pom.xml
+++ b/repl/scala-2.12/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-repl_2.12</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-repl-parent</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/pom.xml
+++ b/scala-api/pom.xml
@@ -23,12 +23,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>multi-scala-project-root</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../scala/pom.xml</relativePath>
   </parent>
 
   <artifactId>livy-scala-api-parent</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <dependencies>

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.11/pom.xml
+++ b/scala-api/scala-2.11/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.11</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala-api/scala-2.12/pom.xml
+++ b/scala-api/scala-2.12/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-scala-api_2.12</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-scala-api-parent</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -21,13 +21,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.livy</groupId>
   <artifactId>multi-scala-project-root</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,11 +23,11 @@
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <artifactId>livy-server</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.7.1.3.2.3.2-3</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.7.1.3.2.3.2-2</version>
+  <version>0.7.1.3.2.3.2-3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+  <version>0.7.1.3.2.2.0-1095</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/test-lib/pom.xml
+++ b/test-lib/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
   </parent>
 
   <groupId>org.apache.livy</groupId>
   <artifactId>livy-test-lib</artifactId>
-  <version>0.7.1.3.2.2.0-1095</version>
+  <version>0.7.1.3.2.3.2-2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/client/pom.xml
+++ b/thriftserver/client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -194,6 +194,11 @@
       <artifactId>apacheds-core-integ</artifactId>
       <version>${apacheds.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -195,6 +195,11 @@
       <version>${apacheds.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -194,11 +194,6 @@
       <artifactId>apacheds-core-integ</artifactId>
       <version>${apacheds.version}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.14.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>livy-main</artifactId>
     <groupId>org.apache.livy</groupId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyCLIService.scala
@@ -385,6 +385,16 @@ class LivyCLIService(server: LivyThriftServer)
   def getQueryId(opHandle: TOperationHandle): String = {
     throw new HiveSQLException("Operation not yet supported.")
   }
+
+  @throws[HiveSQLException]
+  def uploadData(): Nothing = {
+    throw new HiveSQLException("Operation not yet supported.")
+  }
+
+  @throws[HiveSQLException]
+  def downloadData(): Nothing = {
+    throw new HiveSQLException("Operation not yet supported.")
+  }
 }
 
 

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/LdapAuthenticationProviderImpl.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/LdapAuthenticationProviderImpl.scala
@@ -18,7 +18,7 @@ package org.apache.livy.thriftserver.auth
 
 import javax.security.sasl.AuthenticationException
 
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.hive.service.auth.PasswdAuthenticationProvider
 
 import org.apache.livy.thriftserver.auth.ldap._

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftBinaryCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftBinaryCLIService.scala
@@ -23,7 +23,13 @@ import java.util.concurrent._
 import javax.net.ssl.SSLServerSocket
 
 import org.apache.hive.service.cli.HiveSQLException
+import org.apache.hive.service.cli.SessionHandle
+import org.apache.hive.service.rpc.thrift.TDownloadDataReq
+import org.apache.hive.service.rpc.thrift.TDownloadDataResp
+import org.apache.hive.service.rpc.thrift.TUploadDataReq
+import org.apache.hive.service.rpc.thrift.TUploadDataResp
 import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup
+import org.apache.thrift.TException
 import org.apache.thrift.TProcessorFactory
 import org.apache.thrift.protocol.{TBinaryProtocol, TProtocol}
 import org.apache.thrift.server.{ServerContext, TServer, TServerEventHandler, TThreadPoolServer}
@@ -172,5 +178,33 @@ class ThriftBinaryCLIService(override val cliService: LivyCLIService, val oomHoo
     server.stop()
     server = null
     info("Thrift server has stopped")
+  }
+
+  @throws[TException]
+  override def UploadData(req: TUploadDataReq): TUploadDataResp = {
+    val resp = new TUploadDataResp
+    try {
+      val sessionHandle = new SessionHandle(req.getSessionHandle)
+      cliService.uploadData()
+    } catch {
+      case e: Exception =>
+        warn("Error UploadData: ", e)
+        resp.setStatus(HiveSQLException.toTStatus(e))
+    }
+    resp
+  }
+
+  @throws[TException]
+  def DownloadData(req: TDownloadDataReq): TDownloadDataResp = {
+    val resp = new TDownloadDataResp
+    try {
+      val sessionHandle = new SessionHandle(req.getSessionHandle)
+      cliService.downloadData()
+    } catch {
+      case e: Exception =>
+        warn("Error download data: ", e)
+        resp.setStatus(HiveSQLException.toTStatus(e))
+    }
+    resp
   }
 }

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
@@ -21,9 +21,16 @@ import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.TimeUnit
 import javax.ws.rs.HttpMethod
 
+import org.apache.hive.service.cli.HiveSQLException
+import org.apache.hive.service.cli.SessionHandle
 import org.apache.hive.service.rpc.thrift.TCLIService
+import org.apache.hive.service.rpc.thrift.TDownloadDataReq
+import org.apache.hive.service.rpc.thrift.TDownloadDataResp
+import org.apache.hive.service.rpc.thrift.TUploadDataReq
+import org.apache.hive.service.rpc.thrift.TUploadDataResp
 import org.apache.hive.service.server.ThreadFactoryWithGarbageCleanup
 import org.apache.thrift.protocol.TBinaryProtocol
+import org.apache.thrift.TException
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
 import org.eclipse.jetty.server.Server
@@ -202,6 +209,34 @@ class ThriftHttpCLIService(
       error("Error stopping HTTP server: ", e)
       }
     }
+  }
+
+  @throws[TException]
+  override def UploadData(req: TUploadDataReq): TUploadDataResp = {
+    val resp = new TUploadDataResp
+    try {
+      val sessionHandle = new SessionHandle(req.getSessionHandle)
+      cliService.uploadData()
+    } catch {
+      case e: Exception =>
+        warn("Error UploadData: ", e)
+        resp.setStatus(HiveSQLException.toTStatus(e))
+    }
+    resp
+  }
+
+  @throws[TException]
+  def DownloadData(req: TDownloadDataReq): TDownloadDataResp = {
+    val resp = new TDownloadDataResp
+    try {
+      val sessionHandle = new SessionHandle(req.getSessionHandle)
+      cliService.downloadData()
+    } catch {
+      case e: Exception =>
+        warn("Error download data: ", e)
+        resp.setStatus(HiveSQLException.toTStatus(e))
+    }
+    resp
   }
 }
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-2</version>
+    <version>0.7.1.3.2.3.2-3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.2.0-1095</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.0-SNAPSHOT</version>
+    <version>0.7.1.3.2.2.0-1095</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/thriftserver/session/pom.xml
+++ b/thriftserver/session/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.livy</groupId>
     <artifactId>livy-main</artifactId>
-    <version>0.7.1.3.2.3.2-3</version>
+    <version>0.7.1.3.2.3.2-2</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
ODP-2017 Livy CVE's reconciliation from ODP-3.2.3.2-3 to ODP-main.

Ref: https://github.com/acceldata-io/livy/compare/ODP-main...acceldata-io:livy:ODP-3.2.3.2-3-tag