### PR TITLE
ODP-2035 Livy CVE's reconciliation from ODP-3.2.3.2-3 to ODP-3.3.6.0-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,7 @@
     <module>server</module>
     <module>test-lib</module>
     <module>integration-test</module>
+    <module>thriftserver/server</module>
   </modules>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1273,7 +1273,7 @@
     <profile>
       <id>hadoop3</id>
       <properties>
-        <hadoop.major-minor.version>3.3</hadoop.major-minor.version>
+        <hadoop.major-minor.version>3</hadoop.major-minor.version>
         <hadoop.version>3.3.6.3.3.6.0-1</hadoop.version>
       </properties>
     </profile>

--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -200,6 +200,11 @@
       <version>${apacheds.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/LivyCLIService.scala
@@ -385,6 +385,16 @@ class LivyCLIService(server: LivyThriftServer)
   def getQueryId(opHandle: TOperationHandle): String = {
     throw new HiveSQLException("Operation not yet supported.")
   }
+
+  @throws[HiveSQLException]
+  def uploadData(): Nothing = {
+    throw new HiveSQLException("Operation not yet supported.")
+  }
+
+  @throws[HiveSQLException]
+  def downloadData(): Nothing = {
+    throw new HiveSQLException("Operation not yet supported.")
+  }
 }
 
 

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/LdapAuthenticationProviderImpl.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/auth/LdapAuthenticationProviderImpl.scala
@@ -18,7 +18,7 @@ package org.apache.livy.thriftserver.auth
 
 import javax.security.sasl.AuthenticationException
 
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.hive.service.auth.PasswdAuthenticationProvider
 
 import org.apache.livy.thriftserver.auth.ldap._


### PR DESCRIPTION
## What changes were proposed in this pull request?

[use ODP version instead of apache](https://github.com/acceldata-io/livy/commit/ee434b1d2897deb92fae9201861a8a7ef108844e)

changed hadoop.major-minor.version as 3 