### PR TITLE
ODP-2117: Fix Livy when running Pyspark

### DIFF
--- a/repl/src/main/resources/fake_shell.py
+++ b/repl/src/main/resources/fake_shell.py
@@ -589,8 +589,12 @@ def main():
             java_import(gateway.jvm, "org.apache.spark.SparkConf")
             java_import(gateway.jvm, "org.apache.spark.api.java.*")
             java_import(gateway.jvm, "org.apache.spark.api.python.*")
+            java_import(gateway.jvm, "org.apache.spark.ml.python.*")
             java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
+            java_import(gateway.jvm, "org.apache.spark.resource.*")
+
             java_import(gateway.jvm, "org.apache.spark.sql.*")
+            java_import(gateway.jvm, "org.apache.spark.sql.api.python.*")
             java_import(gateway.jvm, "org.apache.spark.sql.hive.*")
             java_import(gateway.jvm, "scala.Tuple2")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When submitting a pyspark job through livy, depending on which spark libraries you use, you receive a `TypeError: 'JavaPackage' object is not callable`. There is a similar upstream issue to this at [LIVY-863](https://issues.apache.org/jira/browse/LIVY-863). The issue was 3 missing java imports in fake_shell.py

## How was this patch tested?
This patch was tested in a local environment, submitting the job through Jupyter