### PR TITLE
ODP-2718 | ODP-2795 : Refactor livy to use ambari-python-wrap

### DIFF
--- a/dev/livy-shell
+++ b/dev/livy-shell
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/integration-test/src/test/resources/batch.py
+++ b/integration-test/src/test/resources/batch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env /python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
ODP-2718 | ODP-2795 : Refactor livy to use ambari-python-wrap