### PR TITLE
ODP-3478: Fix CVE-2020-25638 remove org.hibernate:hibernate-core in Livy

### DIFF
--- a/thriftserver/server/pom.xml
+++ b/thriftserver/server/pom.xml
@@ -55,6 +55,10 @@
       <version>${hive.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-core</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>xalan</groupId>
           <artifactId>xalan</artifactId>
         </exclusion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
