### PR TITLE
OCR-2436|[LIVY-1012] Use SslContextFactory.Server() instead of SslContextFactory

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/WebServer.scala
+++ b/server/src/main/scala/org/apache/livy/server/WebServer.scala
@@ -50,7 +50,7 @@ class WebServer(livyConf: LivyConf, var host: String, var port: Int) extends Log
       https.setSendServerVersion(livyConf.getBoolean(LivyConf.SEND_SERVER_VERSION))
       https.addCustomizer(new SecureRequestCustomizer())
 
-      val sslContextFactory = new SslContextFactory()
+      val sslContextFactory = new SslContextFactory.Server()
       sslContextFactory.setKeyStorePath(keystore)
 
       val credentialProviderPath = livyConf.get(LivyConf.HADOOP_CREDENTIAL_PROVIDER_PATH)

--- a/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
+++ b/thriftserver/server/src/main/scala/org/apache/livy/thriftserver/cli/ThriftHttpCLIService.scala
@@ -95,7 +95,7 @@ class ThriftHttpCLIService(
               s"${LivyConf.SSL_KEYSTORE.key} Not configured for SSL connection")
           }
           val keyStorePassword = getKeyStorePassword()
-          val sslContextFactory = new SslContextFactory
+          val sslContextFactory = new SslContextFactory.Server();
           val excludedProtocols = livyConf.get(LivyConf.THRIFT_SSL_PROTOCOL_BLACKLIST).split(",")
           info(s"HTTP Server SSL: adding excluded protocols: $excludedProtocols")
           sslContextFactory.addExcludeProtocols(excludedProtocols: _*)


### PR DESCRIPTION

## What changes were proposed in this pull request?

Use SslContextFactory.Server() instead of SslContextFactory() when constructing the factory.

## How was this patch tested?

With Jetty 9.4.50, we should call SslContextFactory.Server(), instead of SslContextFactory(), to create SslContextFactory. Otherwise we get the following error when using a KeyStore with multiple certificates in it.

```
Exception in thread "main" java.lang.IllegalStateException: KeyStores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory. (Use org.eclipse.jetty.util.ssl.
SslContextFactory$Server or org.eclipse.jetty.util.ssl.SslContextFactory$Client instead)
at org.eclipse.jetty.util.ssl.SslContextFactory.newSniX509ExtendedKeyManager(SslContextFactory.java:1289)
```

(cherry picked from commit df691033b11440837c2a06fe624510bdbf815fd5)

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
