### PR TITLE
OSV-18267 - CVE - Increasing jackson version to fix GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <hadoop-thirdparty.version>1.4.0</hadoop-thirdparty.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.4</httpcore.version>
-    <jackson.version>2.15.4</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <jackson-databind.version>${jackson.version}</jackson-databind.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jetty.version>9.4.57.v20241219</jetty.version>


### PR DESCRIPTION
- Library : com.fasterxml.jackson.core_jackson-core
- Version : -> 2.18.6
- Tickets : OSV-18267