### PR TITLE
OSV-20747 - CVE - Increasing netty version to fix CVE-2026-42583

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <kryo.version>4.0.2</kryo.version>
     <metrics.version>4.2.30</metrics.version>
     <mockito.version>1.10.19</mockito.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scalatest.version>3.0.8</scalatest.version>
     <scalatra.version>2.8.4</scalatra.version>
@@ -1572,7 +1572,7 @@
         <java.version>1.8</java.version>
         <py4j.version>0.10.9.7</py4j.version>
         <json4s.version>3.7.0-M11</json4s.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <spark.bin.name>spark-${spark.version}-bin-hadoop${hadoop.major-minor.version}</spark.bin.name>
         <spark.bin.download.url>
           https://mirror.odp.acceldata.dev/ODP/standalone/3.2.3.6-2/spark-${spark.version}-bin-${hadoop.version}.tgz

--- a/pom.xml
+++ b/pom.xml
@@ -1572,7 +1572,7 @@
         <java.version>1.8</java.version>
         <py4j.version>0.10.9.7</py4j.version>
         <json4s.version>3.7.0-M11</json4s.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <spark.bin.name>spark-${spark.version}-bin-hadoop${hadoop.major-minor.version}</spark.bin.name>
         <spark.bin.download.url>
           https://mirror.odp.acceldata.dev/ODP/standalone/3.2.3.6-2/spark-${spark.version}-bin-${hadoop.version}.tgz


### PR DESCRIPTION
- Library : io.netty_netty-codec, io.netty_netty-codec-dns, io.netty_netty-codec-http, io.netty_netty-codec-http2, io.netty_netty-codec-mqtt, io.netty_netty-codec-redis
- Version : -> 4.1.135.Final
- Tickets : OSV-20747, OSV-20735, OSV-20732, OSV-20731, OSV-20730, OSV-20729, OSV-20728, OSV-20727, OSV-20726, OSV-20699, OSV-20692