### PR TITLE
OSV-20679 - CVE - Increasing commons-configuration2 version to fix CVE-2026-45205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.11.0</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
- Library : org.apache.commons_commons-configuration2
- Version : -> 2.15.0
- Tickets : OSV-20679